### PR TITLE
Integrate Vulkan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ CMakeSettings.json
 compile_commands.json
 /CMakePresets.json
 /CMakeUserPresets.json
+
+examples/out/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,10 @@
 [submodule "ext/glfw"]
 	path = ext/glfw
 	url = https://github.com/GLFW/glfw
+	shallow = true
 [submodule "ext/dyvk"]
 	path = ext/dyvk
 	url = https://github.com/karnkaul/dyvk
+[submodule "ext/vk-bootstrap"]
+	path = ext/vk-bootstrap
+	url = https://github.com/charles-lunarg/vk-bootstrap

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ target_link_libraries(${PROJECT_NAME}
     glfw
     ${PROJECT_NAME}::interface
   PRIVATE
+    vk-bootstrap::vk-bootstrap
     ${PROJECT_NAME}::options
 )
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ A small quick-start library that provides a GLFW / Vulkan backend for Dear ImGui
 
 WIP
 
+## External Dependencies
+
+- [glfw](https://github.com/GLFW/glfw)
+- [vk-bootstrap](https://github.com/charles-lunarg/vk-bootstrap)
+- [dyvk](https://github.com/karnkaul/dyvk)
+- [ktl](https://github.com/karnkaul/ktl)
+
 [Original repository](https://github.com/cpp-gamedev/dibs)
 
 [LICENCE](LICENSE)

--- a/cmake/interface/CMakeLists.txt
+++ b/cmake/interface/CMakeLists.txt
@@ -14,7 +14,10 @@ else()
   set(gcc_like FALSE)
 endif()
 
-target_compile_definitions(interface INTERFACE $<$<BOOL:${MSVC_RUNTIME}>:WIN32_LEAN_AND_MEAN NOMINMAX _CRT_SECURE_NO_WARNINGS>)
+target_compile_definitions(interface INTERFACE
+  $<$<CONFIG:Debug>:DIBS_DEBUG>
+  $<$<BOOL:${MSVC_RUNTIME}>:WIN32_LEAN_AND_MEAN NOMINMAX _CRT_SECURE_NO_WARNINGS>
+)
 target_compile_features(interface INTERFACE ${cxx_standard})
 
 # options

--- a/config.cmake.in
+++ b/config.cmake.in
@@ -6,6 +6,7 @@ find_dependency(ktl)
 find_dependency(glfw3)
 find_dependency(dyvk)
 
+include("${CMAKE_CURRENT_LIST_DIR}/vk-bootstrap-targets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 
 check_required_components(@PROJECT_NAME@)

--- a/dibs_headers.cmake
+++ b/dibs_headers.cmake
@@ -1,5 +1,7 @@
 target_sources(${PROJECT_NAME} PRIVATE
+  include/dibs/bridge.hpp
   include/dibs/dibs.hpp
   include/dibs/error.hpp
   include/dibs/vec2.hpp
+  include/dibs/vk_types.hpp
 )

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -11,7 +11,7 @@ int main() {
 	}
 	while (!instance->closing()) {
 		instance->poll();
-		auto frame = dibs::Frame(*instance);
+		auto frame = dibs::Frame(*instance, {0.4f, 0.2f, 0.2f, 1.0f});
 		// tick / draw
 	}
 }

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -9,5 +9,9 @@ int main() {
 		std::cerr << "fail! error: " << (int)instance.error() << "\n";
 		return 0;
 	}
-	while (!instance->closing()) { instance->poll(); }
+	while (!instance->closing()) {
+		instance->poll();
+		auto frame = dibs::Frame(*instance);
+		// tick / draw
+	}
 }

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -12,3 +12,24 @@ export(EXPORT glfwTargets)
 
 # dyvk
 add_subdirectory(dyvk)
+
+# vk-bootstrap
+set(VK_BOOTSTRAP_VULKAN_HEADER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/dyvk/include" CACHE STRING "" FORCE)
+if(NOT EXISTS "${VK_BOOTSTRAP_VULKAN_HEADER_DIR}/vulkan/vulkan.h")
+  message(FATAL_ERROR "Missing vulkan headers")
+endif()
+
+add_subdirectory(vk-bootstrap)
+install(TARGETS
+    vk-bootstrap
+    vk-bootstrap-compiler-warnings
+    vk-bootstrap-vulkan-headers
+  EXPORT
+    vk-bootstrap-targets
+)
+install(EXPORT vk-bootstrap-targets
+  FILE vk-bootstrap-targets.cmake
+  NAMESPACE vk-bootstrap::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+export(EXPORT vk-bootstrap-targets)

--- a/include/dibs/bridge.hpp
+++ b/include/dibs/bridge.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <GLFW/glfw3.h>
+#include <dibs/dibs.hpp>
+#include <dibs/vk_types.hpp>
+
+namespace dibs {
+class Bridge {
+  public:
+	static VKDevice const& vulkan(Instance const& instance) noexcept;
+	static GLFWwindow* glfw(Instance const& instance) noexcept;
+	static vk::CommandBuffer drawCmd(Frame const& frame) noexcept;
+};
+} // namespace dibs

--- a/include/dibs/dibs.hpp
+++ b/include/dibs/dibs.hpp
@@ -2,6 +2,7 @@
 #include <dibs/error.hpp>
 #include <dibs/vec2.hpp>
 #include <ktl/enum_flags/enum_flags.hpp>
+#include <array>
 #include <chrono>
 #include <memory>
 
@@ -35,12 +36,17 @@ class Instance {
 
 class Frame {
   public:
-	[[nodiscard]] Frame(Instance const& instance);
+	// TODO: 32-bit colour
+	using Clear = std::array<float, 4>;
+
+	[[nodiscard]] Frame(Instance const& instance, Clear const& clear = {});
 	~Frame();
 
+	bool ready() const noexcept;
 	uvec2 extent() const noexcept;
 
   private:
+	Clear m_clear;
 	Instance const& m_instance;
 	friend class Bridge;
 };

--- a/include/dibs/dibs.hpp
+++ b/include/dibs/dibs.hpp
@@ -22,11 +22,27 @@ class Instance {
 	bool closing() const noexcept;
 	Time poll() noexcept;
 
+	uvec2 framebufferSize() const noexcept;
+	uvec2 windowSize() const noexcept;
+
   private:
 	struct Impl;
 	Instance(std::unique_ptr<Impl>&& impl) noexcept;
-
 	std::unique_ptr<Impl> m_impl;
+	friend class Bridge;
+	friend class Frame;
+};
+
+class Frame {
+  public:
+	[[nodiscard]] Frame(Instance const& instance);
+	~Frame();
+
+	uvec2 extent() const noexcept;
+
+  private:
+	Instance const& m_instance;
+	friend class Bridge;
 };
 
 class Instance::Builder {

--- a/include/dibs/error.hpp
+++ b/include/dibs/error.hpp
@@ -6,8 +6,9 @@ enum class Error {
 	eDuplicateInstance,
 	eUnsupportedPlatform,
 	eGlfwInitFailure,
+	eVulkanInitFailure,
 	eWindowCreationFailure,
-	eInvalidExtent,
+	eInvalidArg,
 };
 
 template <typename T>

--- a/include/dibs/vec2.hpp
+++ b/include/dibs/vec2.hpp
@@ -7,7 +7,7 @@ struct tvec2 {
 	T x{}, y{};
 };
 
-using ivec2 = tvec2<std::uint32_t>;
-using uvec2 = tvec2<std::uint64_t>;
+using ivec2 = tvec2<std::int32_t>;
+using uvec2 = tvec2<std::uint32_t>;
 using vec2 = tvec2<float>;
 } // namespace dibs

--- a/include/dibs/vk_types.hpp
+++ b/include/dibs/vk_types.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <vulkan/vulkan.hpp>
+
+namespace dibs {
+struct VKGpu {
+	vk::PhysicalDeviceProperties properties;
+	std::vector<vk::SurfaceFormatKHR> formats;
+	vk::PhysicalDevice device;
+};
+
+struct VKQueue {
+	vk::Queue queue;
+	std::uint32_t family{};
+};
+
+struct VKDevice {
+	VKGpu gpu;
+	vk::Instance instance;
+	vk::Device device;
+	VKQueue queue;
+};
+} // namespace dibs

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,5 @@
+add_subdirectory(detail)
+
 target_sources(${PROJECT_NAME} PRIVATE
-  detail/glfw_instance.hpp
-  detail/log.hpp
-  detail/unique.hpp
   dibs.cpp
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_subdirectory(detail)
 
 target_sources(${PROJECT_NAME} PRIVATE
+  bridge.cpp
   dibs.cpp
+  instance_impl.hpp
 )

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -1,0 +1,20 @@
+#include <detail/expect.hpp>
+#include <dibs/bridge.hpp>
+#include <instance_impl.hpp>
+
+namespace dibs {
+VKDevice const& Bridge::vulkan(Instance const& instance) noexcept {
+	EXPECT(instance.m_impl);
+	return instance.m_impl->device;
+}
+
+GLFWwindow* Bridge::glfw(Instance const& instance) noexcept {
+	EXPECT(instance.m_impl);
+	return instance.m_impl->glfw.window;
+}
+
+vk::CommandBuffer Bridge::drawCmd(Frame const& frame) noexcept {
+	EXPECT(frame.m_instance.m_impl->acquired);
+	return frame.m_instance.m_impl->frameSync.get().cb;
+}
+} // namespace dibs

--- a/src/detail/CMakeLists.txt
+++ b/src/detail/CMakeLists.txt
@@ -1,7 +1,10 @@
 target_sources(${PROJECT_NAME} PRIVATE
+  expect.hpp
   glfw_instance.hpp
   log.hpp
   unique.hpp
   vk_instance.cpp
   vk_instance.hpp
+  vk_surface.hpp
+  vk_surface.cpp
 )

--- a/src/detail/CMakeLists.txt
+++ b/src/detail/CMakeLists.txt
@@ -1,0 +1,7 @@
+target_sources(${PROJECT_NAME} PRIVATE
+  glfw_instance.hpp
+  log.hpp
+  unique.hpp
+  vk_instance.cpp
+  vk_instance.hpp
+)

--- a/src/detail/CMakeLists.txt
+++ b/src/detail/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(${PROJECT_NAME} PRIVATE
+  defer_queue.hpp
   expect.hpp
   glfw_instance.hpp
   log.hpp

--- a/src/detail/defer_queue.hpp
+++ b/src/detail/defer_queue.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <deque>
+#include <memory>
+#include <vector>
+
+namespace dibs::detail {
+class DeferQueue {
+  public:
+	DeferQueue(std::size_t buffer = 3U) : m_lists(buffer) {}
+
+	template <typename T>
+	void defer(T t) {
+		m_current.push_back(std::make_unique<Wrap<T>>(std::move(t)));
+	}
+
+	void next() {
+		m_lists.pop_front();
+		m_lists.push_back(std::move(m_current));
+	}
+
+  private:
+	struct Base {
+		virtual ~Base() = default;
+	};
+	template <typename T>
+	struct Wrap : Base {
+		T t;
+		Wrap(T t) noexcept(std::is_nothrow_move_constructible_v<T>) : t(std::move(t)) {}
+	};
+
+	using List = std::vector<std::unique_ptr<Base>>;
+
+	List m_current;
+	std::deque<List> m_lists;
+};
+} // namespace dibs::detail

--- a/src/detail/expect.hpp
+++ b/src/detail/expect.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <detail/log.hpp>
+#include <ktl/debug_trap.hpp>
+
+#define EXPECT(predicate)                                                                                                                                      \
+	do {                                                                                                                                                       \
+		if (!(predicate)) {                                                                                                                                    \
+			::dibs::trace("Expect failed: {}", #predicate);                                                                                                    \
+			KTL_DEBUG_TRAP();                                                                                                                                  \
+		}                                                                                                                                                      \
+	} while (false)

--- a/src/detail/log.hpp
+++ b/src/detail/log.hpp
@@ -3,8 +3,20 @@
 #include <iostream>
 
 namespace dibs {
+constexpr bool debug_v =
+#if defined(DIBS_DEBUG)
+	true;
+#else
+	false;
+#endif
+
 template <typename... Args>
 void log(std::string_view fmt, Args const&... args) {
 	std::cout << ktl::format(fmt, args...) << '\n';
+}
+
+template <typename... Args>
+void trace(std::string_view fmt, Args const&... args) {
+	if constexpr (debug_v) { log(fmt, args...); }
 }
 } // namespace dibs

--- a/src/detail/vk_instance.cpp
+++ b/src/detail/vk_instance.cpp
@@ -1,0 +1,35 @@
+#include <VkBootstrap.h>
+#include <detail/vk_instance.hpp>
+
+namespace dibs::detail {
+Result<VKInstance> VKInstance::make(MakeSurface makeSurface, Flags flags) {
+	if (!makeSurface) { return Error::eInvalidArg; }
+	vk::DynamicLoader dl;
+	VULKAN_HPP_DEFAULT_DISPATCHER.init(dl.getProcAddress<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr"));
+	vkb::InstanceBuilder vib;
+	if (flags.test(Flag::eValidation)) { vib.request_validation_layers(); }
+	auto vi = vib.set_app_name("dibs").use_default_debug_messenger().build();
+	if (!vi) { return Error::eVulkanInitFailure; }
+	VULKAN_HPP_DEFAULT_DISPATCHER.init(vi->instance);
+	VKInstance ret;
+	ret.instance = vk::UniqueInstance(vi->instance, {nullptr});
+	ret.messenger = vk::UniqueDebugUtilsMessengerEXT(vi->debug_messenger, {vi->instance});
+	auto surface = makeSurface(vk::Instance(vi->instance));
+	if (!surface) { return Error::eVulkanInitFailure; }
+	ret.surface = vk::UniqueSurfaceKHR(surface, {vi->instance});
+	vkb::PhysicalDeviceSelector vpds(vi.value());
+	auto vpd = vpds.require_present().prefer_gpu_device_type(vkb::PreferredDeviceType::discrete).set_surface(surface).select();
+	if (!vpd) { return Error::eVulkanInitFailure; }
+	ret.gpu = {vk::PhysicalDeviceProperties(vpd->properties), vk::PhysicalDevice(vpd->physical_device)};
+	vkb::DeviceBuilder vdb(vpd.value());
+	auto vd = vdb.build();
+	if (!vd) { return Error::eVulkanInitFailure; }
+	VULKAN_HPP_DEFAULT_DISPATCHER.init(vd->device);
+	ret.device = vk::UniqueDevice(vd->device, {nullptr});
+	auto queue = vd->get_queue(vkb::QueueType::graphics);
+	auto qfam = vd->get_queue_index(vkb::QueueType::graphics);
+	if (!queue || !qfam) { return Error::eVulkanInitFailure; }
+	ret.queue = VKQueue{vk::Queue(queue.value()), qfam.value()};
+	return ret;
+}
+} // namespace dibs::detail

--- a/src/detail/vk_instance.hpp
+++ b/src/detail/vk_instance.hpp
@@ -1,21 +1,12 @@
 #pragma once
 #include <dibs/error.hpp>
+#include <dibs/vk_types.hpp>
 #include <ktl/async/kfunction.hpp>
 #include <ktl/enum_flags/enum_flags.hpp>
 #include <vulkan/vulkan.hpp>
 
 namespace dibs::detail {
 using MakeSurface = ktl::kfunction<vk::SurfaceKHR(vk::Instance)>;
-
-struct VKGpu {
-	vk::PhysicalDeviceProperties properties;
-	vk::PhysicalDevice device;
-};
-
-struct VKQueue {
-	vk::Queue queue;
-	std::uint32_t family{};
-};
 
 struct VKInstance {
 	enum class Flag { eValidation };

--- a/src/detail/vk_instance.hpp
+++ b/src/detail/vk_instance.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <dibs/error.hpp>
+#include <ktl/async/kfunction.hpp>
+#include <ktl/enum_flags/enum_flags.hpp>
+#include <vulkan/vulkan.hpp>
+
+namespace dibs::detail {
+using MakeSurface = ktl::kfunction<vk::SurfaceKHR(vk::Instance)>;
+
+struct VKGpu {
+	vk::PhysicalDeviceProperties properties;
+	vk::PhysicalDevice device;
+};
+
+struct VKQueue {
+	vk::Queue queue;
+	std::uint32_t family{};
+};
+
+struct VKInstance {
+	enum class Flag { eValidation };
+	using Flags = ktl::enum_flags<Flag, std::uint8_t>;
+
+	vk::UniqueInstance instance;
+	vk::UniqueDebugUtilsMessengerEXT messenger;
+	VKGpu gpu;
+	vk::UniqueDevice device;
+	vk::UniqueSurfaceKHR surface;
+	VKQueue queue;
+
+	static Result<VKInstance> make(MakeSurface makeSurface, Flags flags);
+};
+} // namespace dibs::detail

--- a/src/detail/vk_surface.cpp
+++ b/src/detail/vk_surface.cpp
@@ -1,0 +1,129 @@
+#include <detail/expect.hpp>
+#include <detail/log.hpp>
+#include <detail/vk_surface.hpp>
+#include <algorithm>
+#include <limits>
+#include <span>
+
+namespace dibs::detail {
+namespace {
+constexpr vk::Format imageFormat(std::span<vk::SurfaceFormatKHR const> formats) noexcept {
+	constexpr vk::Format targets[] = {vk::Format::eR8G8B8A8Unorm, vk::Format::eB8G8R8A8Unorm};
+	for (auto const format : formats) {
+		if (format.colorSpace == vk::ColorSpaceKHR::eVkColorspaceSrgbNonlinear) {
+			for (auto const target : targets) {
+				if (format == target) { return format.format; }
+			}
+		}
+	}
+	return formats.empty() ? vk::Format() : formats.front().format;
+}
+
+constexpr std::uint32_t imageCount(vk::SurfaceCapabilitiesKHR const& caps) noexcept {
+	if (caps.maxImageCount < caps.minImageCount) { return std::max(3U, caps.minImageCount); }
+	return std::clamp(3U, caps.minImageCount, caps.maxImageCount);
+}
+
+constexpr vk::Extent2D imageExtent(vk::SurfaceCapabilitiesKHR const& caps, uvec2 const fb) noexcept {
+	constexpr auto limitless_v = std::numeric_limits<std::uint32_t>::max();
+	if (caps.currentExtent.width < limitless_v && caps.currentExtent.height < limitless_v) { return caps.currentExtent; }
+	auto const x = std::clamp(fb.x, caps.minImageExtent.width, caps.maxImageExtent.width);
+	auto const y = std::clamp(fb.y, caps.minImageExtent.height, caps.maxImageExtent.height);
+	return vk::Extent2D{x, y};
+}
+
+constexpr bool needsRefresh(vk::Result const result) noexcept { return result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR; }
+
+vk::UniqueImageView makeImageView(vk::Device const device, vk::Image const image, vk::Format const format) {
+	vk::ImageViewCreateInfo info;
+	info.viewType = vk::ImageViewType::e2D;
+	info.format = format;
+	info.components.r = vk::ComponentSwizzle::eR;
+	info.components.g = vk::ComponentSwizzle::eG;
+	info.components.b = vk::ComponentSwizzle::eB;
+	info.components.a = vk::ComponentSwizzle::eA;
+	info.subresourceRange = {vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1};
+	info.image = image;
+	return device.createImageViewUnique(info);
+}
+} // namespace
+
+vk::SwapchainCreateInfoKHR VKSurface::makeInfo(VKDevice const& device, vk::SurfaceKHR const surface, uvec2 const framebuffer) noexcept {
+	vk::SwapchainCreateInfoKHR ret;
+	ret.surface = surface;
+	ret.presentMode = vk::PresentModeKHR::eFifo;
+	ret.imageUsage = vk::ImageUsageFlagBits::eColorAttachment;
+	ret.queueFamilyIndexCount = 1U;
+	ret.pQueueFamilyIndices = &device.queue.family;
+	ret.imageColorSpace = vk::ColorSpaceKHR::eVkColorspaceSrgbNonlinear;
+	ret.imageArrayLayers = 1U;
+	ret.imageFormat = imageFormat(device.gpu.formats);
+	auto const caps = device.gpu.device.getSurfaceCapabilitiesKHR(surface);
+	ret.imageExtent = imageExtent(caps, framebuffer);
+	ret.minImageCount = imageCount(caps);
+	return ret;
+}
+
+vk::Result VKSurface::refresh(VKDevice const& device, uvec2 const framebuffer) {
+	if (framebuffer.x == 0 || framebuffer.y == 0) { return vk::Result::eNotReady; }
+	info = makeInfo(device, surface, framebuffer);
+	info.oldSwapchain = *swapchain.swapchain;
+	vk::SwapchainKHR vks;
+	auto const ret = device.device.createSwapchainKHR(&info, nullptr, &vks);
+	EXPECT(ret == vk::Result::eSuccess);
+	if (ret == vk::Result::eSuccess) {
+		trace("Swapchain resized: {}x{}", info.imageExtent.width, info.imageExtent.height);
+		retired = std::move(swapchain);
+		swapchain.swapchain = vk::UniqueSwapchainKHR(vks, device.device);
+		auto const images = device.device.getSwapchainImagesKHR(*swapchain.swapchain);
+		for (std::size_t i = 0; i < images.size(); ++i) {
+			swapchain.views.push_back(makeImageView(device.device, images[i], info.imageFormat));
+			swapchain.images.push_back({images[i], *swapchain.views[i]});
+		}
+	}
+	return ret;
+}
+
+std::optional<VKSurface::Acquire> VKSurface::acquire(VKDevice const& device, vk::Semaphore const signal, uvec2 const framebuffer) {
+	static constexpr auto max_wait_v = std::numeric_limits<std::uint64_t>::max();
+	std::uint32_t idx{};
+	auto result = device.device.acquireNextImageKHR(*swapchain.swapchain, max_wait_v, signal, {}, &idx);
+	if (needsRefresh(result)) {
+		if (result = refresh(device, framebuffer); result != vk::Result::eSuccess) { return std::nullopt; }
+	}
+	EXPECT(result == vk::Result::eSuccess);
+	if (result != vk::Result::eSuccess) { return std::nullopt; }
+	auto const i = std::size_t(idx);
+	assert(i < swapchain.images.size());
+	return Acquire{swapchain.images[i], idx};
+}
+
+vk::Result VKSurface::submit(VKDevice const& device, vk::CommandBuffer const cb, Sync const& sync, uvec2 const framebuffer) {
+	static constexpr vk::PipelineStageFlags waitStages = vk::PipelineStageFlagBits::eTopOfPipe;
+	vk::SubmitInfo submitInfo;
+	submitInfo.pWaitDstStageMask = &waitStages;
+	submitInfo.commandBufferCount = 1U;
+	submitInfo.pCommandBuffers = &cb;
+	submitInfo.waitSemaphoreCount = 1U;
+	submitInfo.pWaitSemaphores = &sync.wait;
+	submitInfo.signalSemaphoreCount = 1U;
+	submitInfo.pSignalSemaphores = &sync.ssignal;
+	auto const ret = device.queue.queue.submit(1U, &submitInfo, sync.fsignal);
+	if (needsRefresh(ret)) { return refresh(device, framebuffer); }
+	EXPECT(ret == vk::Result::eSuccess);
+	return ret;
+}
+
+vk::Result VKSurface::present(VKDevice const& device, Acquire const& acquired, vk::Semaphore const wait, uvec2 const framebuffer) {
+	vk::PresentInfoKHR info;
+	info.waitSemaphoreCount = 1;
+	info.pWaitSemaphores = &wait;
+	info.swapchainCount = 1;
+	info.pSwapchains = &*swapchain.swapchain;
+	info.pImageIndices = &acquired.index;
+	auto const ret = device.queue.queue.presentKHR(&info);
+	if (needsRefresh(ret)) { return refresh(device, framebuffer); }
+	EXPECT(ret == vk::Result::eSuccess);
+	return ret;
+}
+} // namespace dibs::detail

--- a/src/detail/vk_surface.hpp
+++ b/src/detail/vk_surface.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#include <dibs/vec2.hpp>
+#include <dibs/vk_types.hpp>
+#include <ktl/fixed_vector.hpp>
+#include <optional>
+
+namespace dibs::detail {
+struct VKImage {
+	vk::Image image;
+	vk::ImageView view;
+};
+
+struct VKSwapchain {
+	ktl::fixed_vector<VKImage, 8> images;
+	ktl::fixed_vector<vk::UniqueImageView, 8> views;
+	vk::UniqueSwapchainKHR swapchain;
+};
+
+struct VKSurface {
+	struct Sync {
+		vk::Semaphore wait;
+		vk::Semaphore ssignal;
+		vk::Fence fsignal;
+	};
+
+	struct Acquire {
+		VKImage image;
+		std::uint32_t index{};
+	};
+
+	vk::SwapchainCreateInfoKHR info;
+	VKSwapchain swapchain;
+	VKSwapchain retired;
+	vk::SurfaceKHR surface;
+
+	static vk::SwapchainCreateInfoKHR makeInfo(VKDevice const& device, vk::SurfaceKHR surface, uvec2 framebuffer) noexcept;
+
+	vk::Result refresh(VKDevice const& device, uvec2 framebuffer);
+	std::optional<Acquire> acquire(VKDevice const& device, vk::Semaphore signal, uvec2 framebuffer);
+	vk::Result submit(VKDevice const& device, vk::CommandBuffer cb, Sync const& sync, uvec2 framebuffer);
+	vk::Result present(VKDevice const& device, Acquire const& acquired, vk::Semaphore wait, uvec2 framebuffer);
+};
+} // namespace dibs::detail

--- a/src/detail/vk_surface.hpp
+++ b/src/detail/vk_surface.hpp
@@ -8,6 +8,7 @@ namespace dibs::detail {
 struct VKImage {
 	vk::Image image;
 	vk::ImageView view;
+	vk::Extent2D extent{};
 };
 
 struct VKSwapchain {

--- a/src/detail/vk_surface.hpp
+++ b/src/detail/vk_surface.hpp
@@ -31,8 +31,8 @@ struct VKSurface {
 
 	vk::SwapchainCreateInfoKHR info;
 	VKSwapchain swapchain;
-	VKSwapchain retired;
 	vk::SurfaceKHR surface;
+	class DeferQueue* deferQueue{};
 
 	static vk::SwapchainCreateInfoKHR makeInfo(VKDevice const& device, vk::SurfaceKHR surface, uvec2 framebuffer) noexcept;
 

--- a/src/dibs.cpp
+++ b/src/dibs.cpp
@@ -1,17 +1,11 @@
-#include <detail/glfw_instance.hpp>
+#include <detail/expect.hpp>
 #include <detail/log.hpp>
-#include <detail/vk_instance.hpp>
 #include <dibs/dibs.hpp>
 #include <dibs/dibs_version.hpp>
-#include <cassert>
+#include <instance_impl.hpp>
 
 namespace dibs {
 namespace {
-struct Glfw {
-	detail::UniqueGlfw instance;
-	detail::UniqueWindow window;
-};
-
 Result<Glfw> makeGlfw(char const* title, uvec2 const extent, Instance::Flags const flags) noexcept {
 	if (detail::g_window) { return Error::eDuplicateInstance; }
 	if (extent.x == 0U || extent.y == 0U) { return Error::eInvalidArg; }
@@ -23,7 +17,7 @@ Result<Glfw> makeGlfw(char const* title, uvec2 const extent, Instance::Flags con
 	return Glfw{std::move(instance), std::move(window)};
 }
 
-bool centre(GLFWwindow* window) {
+bool centre(GLFWwindow* const window) {
 	auto const monitor = glfwGetPrimaryMonitor();
 	if (!monitor) { return false; }
 	auto const mode = glfwGetVideoMode(monitor);
@@ -34,33 +28,132 @@ bool centre(GLFWwindow* window) {
 	glfwSetWindowPos(window, (mode->width - w) / 2, (mode->height - h) / 2);
 	return true;
 }
-} // namespace
 
-using Clock = std::chrono::steady_clock;
+uvec2 getFramebufferSize(GLFWwindow* const window) noexcept {
+	int w{}, h{};
+	glfwGetFramebufferSize(window, &w, &h);
+	return {std::uint32_t(w), std::uint32_t(h)};
+}
 
-struct Instance::Impl {
-	Glfw glfw;
-	detail::VKInstance vulkan;
-	Clock::time_point elapsed = Clock::now();
+uvec2 getWindowSize(GLFWwindow* const window) noexcept {
+	int w{}, h{};
+	glfwGetWindowSize(window, &w, &h);
+	return {std::uint32_t(w), std::uint32_t(h)};
+}
+
+VKDevice initDevice(detail::VKInstance const& inst) noexcept {
+	VKDevice ret;
+	ret.instance = *inst.instance;
+	ret.device = *inst.device;
+	ret.gpu = inst.gpu;
+	ret.queue = inst.queue;
+	return ret;
+}
+
+FrameSync initFrameSync(vk::Device const device, std::uint32_t const queueFamily) {
+	using CPCFB = vk::CommandPoolCreateFlagBits;
+	static constexpr vk::CommandPoolCreateFlags pool_flags_v = CPCFB::eTransient | CPCFB::eResetCommandBuffer;
+	static constexpr vk::CommandBufferLevel cb_lvl_v = vk::CommandBufferLevel::ePrimary;
+	FrameSync ret;
+	for (std::size_t i = 0; i < FrameSync::frames_v; ++i) {
+		ret.sync[i].draw = device.createSemaphoreUnique({});
+		ret.sync[i].present = device.createSemaphoreUnique({});
+		ret.sync[i].drawn = device.createFenceUnique({vk::FenceCreateFlagBits::eSignaled});
+		ret.sync[i].pool = device.createCommandPoolUnique(vk::CommandPoolCreateInfo(pool_flags_v, queueFamily));
+		ret.sync[i].cb = device.allocateCommandBuffers(vk::CommandBufferAllocateInfo(*ret.sync[i].pool, cb_lvl_v, 1U)).front();
+	}
+	return ret;
+}
+
+template <typename T, typename U = T>
+using TPair = std::pair<T, U>;
+
+struct ImageBarrier {
+	TPair<vk::AccessFlags> access;
+	TPair<vk::PipelineStageFlags> stages;
+	vk::CommandBuffer cb;
+	vk::Image image;
+
+	void operator()(TPair<vk::ImageLayout> const& layouts) const {
+		vk::ImageMemoryBarrier barrier;
+		barrier.oldLayout = layouts.first;
+		barrier.newLayout = layouts.second;
+		barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		barrier.image = image;
+		barrier.subresourceRange.aspectMask = vk::ImageAspectFlagBits::eColor;
+		barrier.subresourceRange.levelCount = 1U;
+		barrier.subresourceRange.layerCount = 1U;
+		barrier.srcAccessMask = access.first;
+		barrier.dstAccessMask = access.second;
+		cb.pipelineBarrier(stages.first, stages.second, {}, {}, {}, barrier);
+	}
 };
+} // namespace
 
 Instance::Instance(std::unique_ptr<Impl>&& impl) noexcept : m_impl(std::move(impl)) {}
 Instance::Instance(Instance&&) noexcept = default;
 Instance& Instance::operator=(Instance&&) noexcept = default;
 Instance::~Instance() noexcept {
-	if (m_impl) { detail::g_window = {}; }
+	if (m_impl) {
+		m_impl->device.device.waitIdle();
+		detail::g_window = {};
+	}
 }
 
 bool Instance::closing() const noexcept {
-	assert(m_impl);
+	EXPECT(m_impl);
 	return glfwWindowShouldClose(m_impl->glfw.window);
 }
 
 Time Instance::poll() noexcept {
-	assert(m_impl);
+	EXPECT(m_impl);
 	glfwPollEvents();
 	auto const t = Clock::now();
 	return t - std::exchange(m_impl->elapsed, t);
+}
+
+uvec2 Instance::framebufferSize() const noexcept { return getFramebufferSize(m_impl->glfw.window); }
+uvec2 Instance::windowSize() const noexcept { return getWindowSize(m_impl->glfw.window); }
+
+Frame::Frame(Instance const& instance) : m_instance(instance) {
+	EXPECT(m_instance.m_impl && !m_instance.m_impl->acquired);
+	auto impl = m_instance.m_impl.get();
+	auto& sync = impl->frameSync.get();
+	impl->acquired = impl->surface.acquire(impl->device, *sync.draw, m_instance.framebufferSize());
+	EXPECT(impl->acquired);
+}
+
+Frame::~Frame() {
+	auto impl = m_instance.m_impl.get();
+	EXPECT(impl->acquired);
+	static constexpr auto max_wait_v = std::numeric_limits<std::uint64_t>::max();
+	auto& sync = impl->frameSync.get();
+	impl->device.device.waitForFences(*sync.drawn, true, max_wait_v);
+	impl->device.device.resetFences(*sync.drawn);
+	sync.cb.begin({vk::CommandBufferUsageFlagBits::eOneTimeSubmit});
+	ImageBarrier ib;
+	ib.image = impl->acquired->image.image;
+	ib.cb = sync.cb;
+	ib.access = {{}, vk::AccessFlagBits::eColorAttachmentWrite};
+	ib.stages = {vk::PipelineStageFlagBits::eTopOfPipe, vk::PipelineStageFlagBits::eColorAttachmentOutput};
+	ib({vk::ImageLayout::eUndefined, vk::ImageLayout::eColorAttachmentOptimal});
+	// TODO: render
+	ib.access = {vk::AccessFlagBits::eColorAttachmentWrite, {}};
+	ib.stages = {vk::PipelineStageFlagBits::eColorAttachmentOutput, vk::PipelineStageFlagBits::eBottomOfPipe};
+	ib({vk::ImageLayout::eColorAttachmentOptimal, vk::ImageLayout::ePresentSrcKHR});
+	sync.cb.end();
+	uvec2 const fb = m_instance.framebufferSize();
+	auto res = impl->surface.submit(impl->device, sync.cb, {*sync.draw, *sync.present, *sync.drawn}, fb);
+	if (res == vk::Result::eSuccess) { res = impl->surface.present(impl->device, *impl->acquired, *sync.present, fb); }
+	impl->frameSync.next();
+	impl->acquired.reset();
+	EXPECT(res == vk::Result::eSuccess || res == vk::Result::eSuboptimalKHR || res == vk::Result::eErrorOutOfDateKHR);
+}
+
+uvec2 Frame::extent() const noexcept {
+	auto const ret = m_instance.m_impl->surface.info.imageExtent;
+	return {ret.width, ret.height};
 }
 
 Result<Instance> Instance::Builder::operator()() const {
@@ -74,11 +167,18 @@ Result<Instance> Instance::Builder::operator()() const {
 	auto vulkan = detail::VKInstance::make(std::move(makeSurface), detail::VKInstance::Flag::eValidation);
 	if (!vulkan) { return vulkan.error(); }
 	if (!centre(glfw->window)) { log("Failed to centre window"); }
+	auto const vkd = initDevice(*vulkan);
+	detail::VKSurface surface;
+	surface.surface = *vulkan->surface;
+	if (surface.refresh(vkd, getFramebufferSize(glfw->window)) != vk::Result::eSuccess) { return Error::eVulkanInitFailure; }
 	// all checks passed
 	log("Using GPU: {}", vulkan->gpu.properties.deviceName);
 	auto impl = std::make_unique<Instance::Impl>();
 	impl->glfw = std::move(glfw).value();
 	impl->vulkan = std::move(vulkan).value();
+	impl->device = vkd;
+	impl->surface = std::move(surface);
+	impl->frameSync = initFrameSync(vkd.device, vkd.queue.family);
 	if (!m_flags.test(Flag::eHidden)) { glfwShowWindow(impl->glfw.window); }
 	return Instance(std::move(impl));
 }

--- a/src/dibs.cpp
+++ b/src/dibs.cpp
@@ -65,6 +65,48 @@ FrameSync initFrameSync(vk::Device const device, std::uint32_t const queueFamily
 	return ret;
 }
 
+vk::UniqueRenderPass makeRenderPass(vk::Device device, vk::Format colour, bool autoTransition) {
+	vk::AttachmentDescription attachment;
+	attachment.format = colour;
+	attachment.samples = vk::SampleCountFlagBits::e1;
+	attachment.loadOp = vk::AttachmentLoadOp::eClear;
+	attachment.storeOp = vk::AttachmentStoreOp::eStore;
+	attachment.stencilLoadOp = vk::AttachmentLoadOp::eDontCare;
+	attachment.stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
+	if (autoTransition) {
+		attachment.initialLayout = vk::ImageLayout::eUndefined;
+		attachment.finalLayout = vk::ImageLayout::ePresentSrcKHR;
+	} else {
+		attachment.initialLayout = attachment.finalLayout = vk::ImageLayout::eColorAttachmentOptimal;
+	}
+	vk::AttachmentReference color_attachment;
+	color_attachment.attachment = 0;
+	color_attachment.layout = vk::ImageLayout::eColorAttachmentOptimal;
+	vk::SubpassDescription subpass;
+	subpass.pipelineBindPoint = vk::PipelineBindPoint::eGraphics;
+	subpass.colorAttachmentCount = 1;
+	subpass.pColorAttachments = &color_attachment;
+	vk::SubpassDependency dependency;
+	dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+	dependency.dstSubpass = 0;
+	dependency.srcStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+	dependency.dstStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+	dependency.dstAccessMask = vk::AccessFlagBits::eColorAttachmentWrite;
+	vk::RenderPassCreateInfo info;
+	info.attachmentCount = 1;
+	info.pAttachments = &attachment;
+	info.subpassCount = 1;
+	info.pSubpasses = &subpass;
+	info.dependencyCount = 1;
+	info.pDependencies = &dependency;
+	return device.createRenderPassUnique(info);
+}
+
+vk::UniqueFramebuffer makeFramebuffer(vk::Device device, vk::RenderPass pass, detail::VKImage const& target) {
+	EXPECT(target.extent.width > 0U && target.extent.height > 0U);
+	return device.createFramebufferUnique(vk::FramebufferCreateInfo({}, pass, 1U, &target.view, target.extent.width, target.extent.height, 1U));
+}
+
 template <typename T, typename U = T>
 using TPair = std::pair<T, U>;
 
@@ -116,40 +158,63 @@ Time Instance::poll() noexcept {
 uvec2 Instance::framebufferSize() const noexcept { return getFramebufferSize(m_impl->glfw.window); }
 uvec2 Instance::windowSize() const noexcept { return getWindowSize(m_impl->glfw.window); }
 
-Frame::Frame(Instance const& instance) : m_instance(instance) {
-	EXPECT(m_instance.m_impl && !m_instance.m_impl->acquired);
+Frame::Frame(Instance const& instance, Clear const& clear) : m_clear(clear), m_instance(instance) {
+	EXPECT(m_instance.m_impl && !m_instance.m_impl->acquired); // must not have already acquired an image
 	auto impl = m_instance.m_impl.get();
 	auto& sync = impl->frameSync.get();
+	// acquire next swapchain image to render to
 	impl->acquired = impl->surface.acquire(impl->device, *sync.draw, m_instance.framebufferSize());
-	EXPECT(impl->acquired);
 }
 
 Frame::~Frame() {
 	auto impl = m_instance.m_impl.get();
-	EXPECT(impl->acquired);
-	static constexpr auto max_wait_v = std::numeric_limits<std::uint64_t>::max();
-	auto& sync = impl->frameSync.get();
-	impl->device.device.waitForFences(*sync.drawn, true, max_wait_v);
-	impl->device.device.resetFences(*sync.drawn);
-	sync.cb.begin({vk::CommandBufferUsageFlagBits::eOneTimeSubmit});
-	ImageBarrier ib;
-	ib.image = impl->acquired->image.image;
-	ib.cb = sync.cb;
-	ib.access = {{}, vk::AccessFlagBits::eColorAttachmentWrite};
-	ib.stages = {vk::PipelineStageFlagBits::eTopOfPipe, vk::PipelineStageFlagBits::eColorAttachmentOutput};
-	ib({vk::ImageLayout::eUndefined, vk::ImageLayout::eColorAttachmentOptimal});
-	// TODO: render
-	ib.access = {vk::AccessFlagBits::eColorAttachmentWrite, {}};
-	ib.stages = {vk::PipelineStageFlagBits::eColorAttachmentOutput, vk::PipelineStageFlagBits::eBottomOfPipe};
-	ib({vk::ImageLayout::eColorAttachmentOptimal, vk::ImageLayout::ePresentSrcKHR});
-	sync.cb.end();
-	uvec2 const fb = m_instance.framebufferSize();
-	auto res = impl->surface.submit(impl->device, sync.cb, {*sync.draw, *sync.present, *sync.drawn}, fb);
-	if (res == vk::Result::eSuccess) { res = impl->surface.present(impl->device, *impl->acquired, *sync.present, fb); }
-	impl->frameSync.next();
-	impl->acquired.reset();
-	EXPECT(res == vk::Result::eSuccess || res == vk::Result::eSuboptimalKHR || res == vk::Result::eErrorOutOfDateKHR);
+	if (impl->acquired) {
+		static constexpr auto max_wait_v = std::numeric_limits<std::uint64_t>::max();
+		auto& sync = impl->frameSync.get();
+		// wait for previous draw on this image to complete
+		impl->device.device.waitForFences(*sync.drawn, true, max_wait_v);
+		impl->device.device.resetFences(*sync.drawn);
+		// start recording
+		sync.cb.begin({vk::CommandBufferUsageFlagBits::eOneTimeSubmit});
+		// transition image for shading
+		ImageBarrier ib;
+		ib.image = impl->acquired->image.image;
+		ib.cb = sync.cb;
+		ib.access = {{}, vk::AccessFlagBits::eColorAttachmentWrite};
+		ib.stages = {vk::PipelineStageFlagBits::eTopOfPipe, vk::PipelineStageFlagBits::eColorAttachmentOutput};
+		ib({vk::ImageLayout::eUndefined, vk::ImageLayout::eColorAttachmentOptimal});
+		// make framebuffer corresponding to current image
+		sync.framebuffer = makeFramebuffer(impl->device.device, *impl->renderPass, impl->acquired->image);
+		// perform render pass
+		vk::ClearValue cv = vk::ClearColorValue(m_clear);
+		vk::RenderPassBeginInfo rpbi;
+		rpbi.renderPass = *impl->renderPass;
+		rpbi.framebuffer = *sync.framebuffer;
+		rpbi.renderArea.extent = impl->acquired->image.extent;
+		rpbi.clearValueCount = 1U;
+		rpbi.pClearValues = &cv;
+		sync.cb.beginRenderPass(rpbi, vk::SubpassContents::eInline);
+		// TODO: render Dear ImGui draw data
+		sync.cb.endRenderPass();
+		// transition image for presentation
+		ib.access = {vk::AccessFlagBits::eColorAttachmentWrite, {}};
+		ib.stages = {vk::PipelineStageFlagBits::eColorAttachmentOutput, vk::PipelineStageFlagBits::eBottomOfPipe};
+		ib({vk::ImageLayout::eColorAttachmentOptimal, vk::ImageLayout::ePresentSrcKHR});
+		// stop recording
+		sync.cb.end();
+		uvec2 const fb = m_instance.framebufferSize();
+		// submit commands and present image
+		auto res = impl->surface.submit(impl->device, sync.cb, {*sync.draw, *sync.present, *sync.drawn}, fb);
+		if (res == vk::Result::eSuccess) { res = impl->surface.present(impl->device, *impl->acquired, *sync.present, fb); }
+		// swap buffers
+		impl->frameSync.next();
+		// reset acquired image (submitted to presentation engine)
+		impl->acquired.reset();
+		EXPECT(res == vk::Result::eSuccess || res == vk::Result::eSuboptimalKHR || res == vk::Result::eErrorOutOfDateKHR);
+	}
 }
+
+bool Frame::ready() const noexcept { return m_instance.m_impl->acquired.has_value(); }
 
 uvec2 Frame::extent() const noexcept {
 	auto const ret = m_instance.m_impl->surface.info.imageExtent;
@@ -179,6 +244,7 @@ Result<Instance> Instance::Builder::operator()() const {
 	impl->device = vkd;
 	impl->surface = std::move(surface);
 	impl->frameSync = initFrameSync(vkd.device, vkd.queue.family);
+	impl->renderPass = makeRenderPass(vkd.device, impl->surface.info.imageFormat, false);
 	if (!m_flags.test(Flag::eHidden)) { glfwShowWindow(impl->glfw.window); }
 	return Instance(std::move(impl));
 }

--- a/src/dibs.cpp
+++ b/src/dibs.cpp
@@ -208,6 +208,7 @@ Frame::~Frame() {
 		if (res == vk::Result::eSuccess) { res = impl->surface.present(impl->device, *impl->acquired, *sync.present, fb); }
 		// swap buffers
 		impl->frameSync.next();
+		impl->deferQueue.next();
 		// reset acquired image (submitted to presentation engine)
 		impl->acquired.reset();
 		EXPECT(res == vk::Result::eSuccess || res == vk::Result::eSuboptimalKHR || res == vk::Result::eErrorOutOfDateKHR);
@@ -243,6 +244,7 @@ Result<Instance> Instance::Builder::operator()() const {
 	impl->vulkan = std::move(vulkan).value();
 	impl->device = vkd;
 	impl->surface = std::move(surface);
+	impl->surface.deferQueue = &impl->deferQueue;
 	impl->frameSync = initFrameSync(vkd.device, vkd.queue.family);
 	impl->renderPass = makeRenderPass(vkd.device, impl->surface.info.imageFormat, false);
 	if (!m_flags.test(Flag::eHidden)) { glfwShowWindow(impl->glfw.window); }

--- a/src/instance_impl.hpp
+++ b/src/instance_impl.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#include <detail/glfw_instance.hpp>
+#include <detail/vk_instance.hpp>
+#include <detail/vk_surface.hpp>
+#include <dibs/dibs.hpp>
+
+namespace dibs {
+using Clock = std::chrono::steady_clock;
+
+struct Glfw {
+	detail::UniqueGlfw instance;
+	detail::UniqueWindow window;
+};
+
+struct FrameSync {
+	static constexpr std::size_t frames_v = 2U;
+
+	struct Sync {
+		vk::UniqueSemaphore draw;
+		vk::UniqueSemaphore present;
+		vk::UniqueFence drawn;
+		vk::UniqueCommandPool pool;
+		vk::CommandBuffer cb;
+	};
+
+	Sync sync[frames_v];
+	std::size_t index{};
+
+	Sync& get() noexcept { return sync[index]; }
+	void next() noexcept { index = (index + 1) % frames_v; }
+};
+
+struct Instance::Impl {
+	Glfw glfw;
+	detail::VKInstance vulkan;
+	VKDevice device;
+	detail::VKSurface surface;
+	FrameSync frameSync;
+	std::optional<detail::VKSurface::Acquire> acquired;
+	Clock::time_point elapsed = Clock::now();
+};
+} // namespace dibs

--- a/src/instance_impl.hpp
+++ b/src/instance_impl.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <detail/defer_queue.hpp>
 #include <detail/glfw_instance.hpp>
 #include <detail/vk_instance.hpp>
 #include <detail/vk_surface.hpp>
@@ -37,6 +38,7 @@ struct Instance::Impl {
 	VKDevice device;
 	detail::VKSurface surface;
 	FrameSync frameSync;
+	detail::DeferQueue deferQueue;
 	vk::UniqueRenderPass renderPass;
 	std::optional<detail::VKSurface::Acquire> acquired;
 	Clock::time_point elapsed = Clock::now();

--- a/src/instance_impl.hpp
+++ b/src/instance_impl.hpp
@@ -21,6 +21,7 @@ struct FrameSync {
 		vk::UniqueFence drawn;
 		vk::UniqueCommandPool pool;
 		vk::CommandBuffer cb;
+		vk::UniqueFramebuffer framebuffer;
 	};
 
 	Sync sync[frames_v];
@@ -36,6 +37,7 @@ struct Instance::Impl {
 	VKDevice device;
 	detail::VKSurface surface;
 	FrameSync frameSync;
+	vk::UniqueRenderPass renderPass;
 	std::optional<detail::VKSurface::Acquire> acquired;
 	Clock::time_point elapsed = Clock::now();
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16272243/148009068-d1ad788d-04cb-49c7-be82-531b40bcb6ae.png)

Close #10 

Initialize Vulkan instance, device, swapchain, surface.
Establish presentation loop and wrapper `Frame`.
Keep `dibs.hpp` lightweight - do not include GLFW / Vulkan headers; `class Bridge` in `bridge.hpp` deals with that if the user needs those structures.

Pending:
- [x] render pass

Stretch / other PRs:
- [ ] 32-bit colour (@flyingsl0ths would you like to take this one?)
- [x] defer queue (swapchain image views)